### PR TITLE
Add citation information to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,25 @@ please install the `{remotes}` package from CRAN and then enter into the console
 The development version of RSiena can be similarly installed as:
 
 `remotes::install_github("snlab-nl/rsiena@develop")`
+
+## Citation
+
+To cite the RSiena package in publications use:
+
+> Ruth M. Ripley, Tom A. B. Snijders, Zsofia Boda, Andras Voros, and Paulina Preciado(2023). Manual
+> for Siena version 4.0. R package version 1.3.19.
+> https://www.cran.r-project.org/web/packages/RSiena/.
+
+A BibTeX entry for LaTeX users is
+
+```bib
+@TechReport{,
+  title = {Manual for {Siena} version 4.0},
+  author = {Ruth M. Ripley and Tom A. B. Snijders and Zsofia B'{o}da and Andr'{a}s V"{o}r"{o}s and Paulina Preciado},
+  year = {2023},
+  institution = {Oxford: University of Oxford, Department of Statistics; Nuffield College},
+  note = {R package version 1.3.19. https://www.cran.r-project.org/web/packages/RSiena/},
+}
+```
+
+For more references, see https://www.stats.ox.ac.uk/~snijders/siena/. 


### PR DESCRIPTION
# Description

Dear RSiena developers, thanks for the interesting package. This PR proposes to add citation information to the README, such that people don't have to install the package to see the citation info. This is a good practice in FAIR Software development.

# Checklist:

## Checks

- [x] If possible, I have added tests that prove my fix is effective or that my feature works
- [x] The package builds on my OS without issues
- [x] My changes generate no new warnings

## Documentation

- [x] I have commented my code inline, particularly in hard-to-understand areas
- [x] If function added/modified, I have added/modified documentation (in .R file)
- [x] If effect added/modified, I have added/modified section 12 of the manual
- [ ] I have added a description of all changes to this pull request above and to the NEWS.md file
- [x] I have bumped the version in the DESCRIPTION and man/RSiena-package.md files by the appropriate increment:
  - 'major' (incompatible API changes)
  - 'minor' (add functionality in a backwards compatible manner)
  - 'patch' (backwards compatible bug fixes)

I think not relevant as there are no changes to the code base. 